### PR TITLE
Add coffee-script dep so this can be properly included in projects.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,6 @@
 .npmignore
 .travis.yml
 Gruntfile.coffee
-src
+benchmarks
 test
 tmp

--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('coffee-script');
+module.exports = require('./src/index');

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "xlsx-writer",
   "description": "Simple XLSX writer.",
-  "version": "0.0.9",
+  "version": "0.1.0",
   "homepage": "https://github.com/rubenv/node-xlsx-writer",
   "author": {
     "name": "Ruben Vermeersch",
@@ -21,7 +21,7 @@
       "url": "https://github.com/rubenv/node-xlsx-writer/blob/master/LICENSE"
     }
   ],
-  "main": "lib/index.js",
+  "main": "index.js",
   "engines": {
     "node": ">= 0.8.0"
   },
@@ -34,7 +34,6 @@
     "grunt-contrib-clean": "~0.4.0",
     "grunt": "~0.4.0",
     "grunt-mocha-cli": "~1.0.1",
-    "coffee-script": "~1.6.1",
     "grunt-mkdir": "~0.1.0",
     "excel": "0.0.3",
     "underscore": "~1.4.4",
@@ -48,6 +47,7 @@
   "dependencies": {
     "temp": "~0.5.0",
     "async": "~0.2.6",
-    "zipper": "~0.3.0"
+    "zipper": "~0.3.0",
+    "coffee-script": "~1.6.3"
   }
 }


### PR DESCRIPTION
As it stands this module is not usable via npm - this commit simply fixes .npmignore and includes coffee-script so we don't have to maintain compiled versions in the repo.
